### PR TITLE
Some fixes

### DIFF
--- a/source/scenes/home.cpp
+++ b/source/scenes/home.cpp
@@ -416,6 +416,8 @@ void Home_draw(void) {
 		}
 		if (video_playing_bar_show) video_update_playing_bar(key);
 		
+		if (key.p_a) Search_show_search_keyboard();
+
 		if (key.p_b) global_intent.next_scene = SceneType::BACK;
 	}
 	resource_lock.unlock();

--- a/source/scenes/search.cpp
+++ b/source/scenes/search.cpp
@@ -345,6 +345,8 @@ bool Search_show_search_keyboard() {
 			remove_all_async_tasks_with_type(load_search_results);
 			remove_all_async_tasks_with_type(load_more_search_results);
 			queue_async_task(load_search_results, NULL);
+
+			global_intent.next_scene = SceneType::SEARCH;
 		}
 		if (global_current_scene != SceneType::SEARCH) resource_lock.unlock();
 		return button_pressed == SWKBD_BUTTON_RIGHT;

--- a/source/youtube_parser/internal_common.cpp
+++ b/source/youtube_parser/internal_common.cpp
@@ -6,7 +6,7 @@ void youtube_change_content_language(std::string language_code) {
 	if (language_code == "en") {
 		youtube_parser::country_code = "US";
 	}
-	else if (language_code == "jp") {
+	else if (language_code == "ja") {
 		youtube_parser::country_code = "JP";
 	}
 	else if (language_code == "de") {

--- a/source/youtube_parser/search.cpp
+++ b/source/youtube_parser/search.cpp
@@ -56,7 +56,7 @@ static bool parse_searched_item(RJson content, std::vector<YouTubeSuccinctItem> 
 
         res.push_back(YouTubeSuccinctItem(cur_list));
     } else if (content.has_key("reelShelfRenderer")) {
-        debug_warning("Skipped reelShelfRenderer content");
+        debug_warning("Skipped reelShelfRenderer");
     } else {
         debug_warning("Error: Unexpected content structure");
         success = false; 
@@ -115,6 +115,10 @@ YouTubeSearchResult youtube_load_search(std::string url) {
                 for (auto i : yt_result["contents"]["sectionListRenderer"]["contents"].array_items()) {
                     if (i.has_key("itemSectionRenderer")) {
                         for (auto j : i["itemSectionRenderer"]["contents"].array_items()) {
+                            if (j.has_key("didYouMeanRenderer")) {
+                                debug_warning("Skipped didYouMeanRenderer");
+                                continue;
+                            }
                             if (!parse_searched_item(j, res.results)) {
                                 debug_error("Error parsing search result item");
                                 success = false; 

--- a/source/youtube_parser/search.cpp
+++ b/source/youtube_parser/search.cpp
@@ -57,6 +57,8 @@ static bool parse_searched_item(RJson content, std::vector<YouTubeSuccinctItem> 
         res.push_back(YouTubeSuccinctItem(cur_list));
     } else if (content.has_key("reelShelfRenderer")) {
         debug_warning("Skipped reelShelfRenderer");
+    } else if (content.has_key("showingResultsForRenderer")) {
+        debug_warning("Skipped showingResultsForRenderer");
     } else {
         debug_warning("Error: Unexpected content structure");
         success = false; 


### PR DESCRIPTION
- Fixed Japanese in content language to function correctly
- Press A in the Home to search
- Skip didYouMeanRenderer and showingResultsForRenderer (Workaround for “[se] Unknown error occurred during search load” error)