### PR TITLE
Prefer video_stream_urls and audio_stream_url over both_stream_url

### DIFF
--- a/source/scenes/video_player.cpp
+++ b/source/scenes/video_player.cpp
@@ -1722,13 +1722,13 @@ static void decode_thread(void* arg) {
 			if (audio_only_mode) {
 				result = network_decoder.init(playing_video_info.audio_stream_url, stream_downloader,
 					playing_video_info.is_livestream ? playing_video_info.stream_fragment_len : -1, playing_video_info.needs_timestamp_adjusting(), var_is_new3ds);
+			} else if (playing_video_info.video_stream_urls[(int) video_p_value] != "" && playing_video_info.audio_stream_url != "") {
+				result = network_decoder.init(playing_video_info.video_stream_urls[(int) video_p_value], playing_video_info.audio_stream_url, stream_downloader,
+					playing_video_info.is_livestream ? playing_video_info.stream_fragment_len : -1, playing_video_info.needs_timestamp_adjusting(), var_is_new3ds && (video_p_value == 360 || video_p_value == 480));
 			} else if ((video_p_value == 360 || video_p_value == 480) && playing_video_info.both_stream_url != "") {
 				// itag 18 (both_stream) of a long video takes too much time and sometimes leads to a crash 
 				result = network_decoder.init(playing_video_info.both_stream_url, stream_downloader,
 					playing_video_info.is_livestream ? playing_video_info.stream_fragment_len : -1, playing_video_info.needs_timestamp_adjusting(), var_is_new3ds);
-			} else if (playing_video_info.video_stream_urls[(int) video_p_value] != "" && playing_video_info.audio_stream_url != "") {
-				result = network_decoder.init(playing_video_info.video_stream_urls[(int) video_p_value], playing_video_info.audio_stream_url, stream_downloader,
-					playing_video_info.is_livestream ? playing_video_info.stream_fragment_len : -1, playing_video_info.needs_timestamp_adjusting(), var_is_new3ds && (video_p_value == 360 || video_p_value == 480));
 			} else {
 				result.code = -1;
 				result.string = "YouTube parser error";


### PR DESCRIPTION
Workaround playback issues with some videos like [this video](https://youtu.be/zhlvdGtudsw) when using Android VR or visionOS