### PR TITLE
Refactor video resolution detection logic

### DIFF
--- a/source/scenes/video_player.cpp
+++ b/source/scenes/video_player.cpp
@@ -1168,10 +1168,6 @@ static void load_video_page(void *arg) {
 		std::vector<int> available_qualities;
 		for (auto &i : tmp_video_info.video_stream_urls) available_qualities.push_back(i.first);
 
-		// Remove forced addition of 360p
-		// if (!std::count(available_qualities.begin(), available_qualities.end(), 360))
-		//	available_qualities.insert(std::lower_bound(available_qualities.begin(), available_qualities.end(), 360), 360);
-
 		video_quality_selector_view->button_texts = { (std::function<std::string ()>) []() { return LOCALIZED(OFF); } };
 		for (auto i : available_qualities) if (var_is_new3ds || i <= 240) video_quality_selector_view->button_texts.push_back(std::to_string(i) + "p");
 		video_quality_selector_view->button_num = video_quality_selector_view->button_texts.size();

--- a/source/scenes/video_player.cpp
+++ b/source/scenes/video_player.cpp
@@ -1167,8 +1167,10 @@ static void load_video_page(void *arg) {
 		// prepare the quality selector
 		std::vector<int> available_qualities;
 		for (auto &i : tmp_video_info.video_stream_urls) available_qualities.push_back(i.first);
-		if (!std::count(available_qualities.begin(), available_qualities.end(), 360))
-			available_qualities.insert(std::lower_bound(available_qualities.begin(), available_qualities.end(), 360), 360);
+
+		// Remove forced addition of 360p
+		// if (!std::count(available_qualities.begin(), available_qualities.end(), 360))
+		//	available_qualities.insert(std::lower_bound(available_qualities.begin(), available_qualities.end(), 360), 360);
 
 		video_quality_selector_view->button_texts = { (std::function<std::string ()>) []() { return LOCALIZED(OFF); } };
 		for (auto i : available_qualities) if (var_is_new3ds || i <= 240) video_quality_selector_view->button_texts.push_back(std::to_string(i) + "p");

--- a/source/youtube_parser/video.cpp
+++ b/source/youtube_parser/video.cpp
@@ -57,22 +57,24 @@ static bool extract_player_data(Document &json_root, RJson player_response, YouT
 	}
 	// video
 	{
-		std::map<int, int> itag_to_p = {
-			{160, 144},
-			{133, 240},
-			{134, 360},
-			{135, 480}
-		};
 		for (auto i : video_formats) {
 			int cur_itag = i["itag"].int_value();
-			if (itag_to_p.count(cur_itag)) {
-				int p_value = itag_to_p[cur_itag];
-				res.video_stream_urls[p_value] = i["url"].string_value();
+			std::string url = i["url"].string_value();
+			int height = i["height"].int_value(); // Video resolution height
+
+			// Skip streams with resolution higher than 480p
+			if (height > 480) {
+				continue;
+			}
+
+			logger.info("Stream Info", "itag: " + std::to_string(cur_itag) + 
+						", Resolution: " + std::to_string(height) + "p, URL: " + url);
+
+			// Store the stream URL by resolution
+			if (height > 0) {
+				res.video_stream_urls[height] = url;
 			}
 		}
-		// both_stream_url : search for itag 18
-		for (auto i : video_formats) if (i["itag"].int_value() == 18)
-			res.both_stream_url = i["url"].string_value();
 	}
 	
 	// extract caption data

--- a/source/youtube_parser/video.cpp
+++ b/source/youtube_parser/video.cpp
@@ -67,9 +67,6 @@ static bool extract_player_data(Document &json_root, RJson player_response, YouT
 				continue;
 			}
 
-			logger.info("Stream Info", "itag: " + std::to_string(cur_itag) + 
-						", Resolution: " + std::to_string(height) + "p, URL: " + url);
-
 			// Store the stream URL by resolution
 			if (height > 0) {
 				res.video_stream_urls[height] = url;


### PR DESCRIPTION
Change resolution detection from itag to video height. Fixed #63.
For videos other than 144, 240, 360, and 480 height, itag will continue to be used to determine the resolution. This is for non-16:9 videos such as Shorts
## Screenshots
### https://youtu.be/sS-cDub14hc
![image](https://github.com/user-attachments/assets/16702534-424c-4257-83df-31995887e93e)

### https://youtu.be/DFyCtxUqBHg
![image](https://github.com/user-attachments/assets/d393d293-f96e-4b7e-a6fd-79feaa468902)
