### PR TITLE
Fix two crashes

### DIFF
--- a/source/network_decoder/network_downloader.hpp
+++ b/source/network_decoder/network_downloader.hpp
@@ -55,7 +55,7 @@ struct NetworkStream {
 	std::vector<u8> get_data(u64 start, u64 size);
 
 	// this function is supposed to be called from NetworkStreamDownloader::*
-	void set_data(u64 block, const std::vector<u8> &data);
+	void set_data(u64 block, std::vector<u8> data);
 };
 
 // each instance of this class is paired with one downloader thread

--- a/source/ui/draw/draw.cpp
+++ b/source/ui/draw/draw.cpp
@@ -177,8 +177,8 @@ Result_with_string Draw_c2d_image_init(Image_data *c2d_image, int tex_size_x, in
                                        GPU_TEXCOLOR color_format) {
 	Result_with_string result;
 
-	c2d_image->subtex = (Tex3DS_SubTexture *)linearAlloc_concurrent(sizeof(Tex3DS_SubTexture *));
-	c2d_image->c2d.tex = (C3D_Tex *)linearAlloc_concurrent(sizeof(C3D_Tex *));
+	c2d_image->subtex = (Tex3DS_SubTexture *)linearAlloc_concurrent(sizeof(Tex3DS_SubTexture));
+	c2d_image->c2d.tex = (C3D_Tex *)linearAlloc_concurrent(sizeof(C3D_Tex));
 	if (c2d_image->subtex == NULL || c2d_image->c2d.tex == NULL) {
 		linearFree_concurrent(c2d_image->subtex);
 		linearFree_concurrent(c2d_image->c2d.tex);


### PR DESCRIPTION
Crash 1 (at network_downloader.cpp:61): This crash happened when the app would attempt to copy the vector data to put it into the map. This fix is technically more of a workaround, as it prevents the vector from getting copied, and instead converts it into a rvalue by std::moving it, which means it doesn't need to be copied and can directly be put into the map

Crash 2 (at draw.cpp:123): This crash would happen when the code attempted to set c2d_image->subtex->top to 1.0. This happened because Draw_c2d_image_init didn't allocate the right amount of memory. Instead of allocating the sizeof(Tex3DS_SubTexture) and sizeof(C3D_Tex), it allocated the size of their pointers, meaning it just allocated 4 bytes two times and not the size of the structure. This meant that in linear space, there would be 8 allocated bytes in a row, which fit the width and height, which are both u16 values, filling 4 bytes, and the left variable, which is a 32-bit float, which is 4 bytes, and fills the allocated RAM. When attempting to set top, which happens at an offset of exactly 8 bytes, it wanders off into unallocated memory, which is known as undefined behavior and leads to random segfaults.

If you have any questions or complaints, please ask, I will be happy to respond and discuss any potential issues, as I am not sure if any of my changes may be break something else in the codebase